### PR TITLE
Move autocmd to augroup

### DIFF
--- a/plugin/cheat.vim
+++ b/plugin/cheat.vim
@@ -158,7 +158,10 @@ endif
 
 if(!exists("g:CheatSheetDisableFrameworkDetection")
             \ || g:CheatSheetDisableFrameworkDetection == 0)
-    autocmd! BufReadPost,BufNewFile * call cheat#frameworks#autodetect(0)
+    augroup cheat_group
+        autocmd!
+        autocmd BufReadPost,BufNewFile * call cheat#frameworks#autodetect(0)
+    augroup END
 endif
 
 try


### PR DESCRIPTION
autocmd! (with the bang) removes all autcmds including those in my vimrc

Moving the autocmd to a group means the bang will only remove
autocmds previously added by the same group.

See http://vimdoc.sourceforge.net/htmldoc/autocmd.html for more
information